### PR TITLE
Ensure focused state is cleared when blurring the datepicker input

### DIFF
--- a/dist/react-datepicker.js
+++ b/dist/react-datepicker.js
@@ -3630,8 +3630,8 @@
             !0 !== r.props.accessibleMode &&
               (!r.state.open || r.props.withPortal || r.props.showTimeInput
                 ? r.props.onBlur(e)
-                : r.deferFocusInput(),
-              r.setState({ focused: !1 }));
+                : r.deferFocusInput()),
+              r.setState({ focused: !1 });
           }),
           ue(ve(r), "handleCalendarClickOutside", function(e) {
             r.props.inline || r.setOpen(!1),

--- a/dist/react-datepicker.min.js
+++ b/dist/react-datepicker.min.js
@@ -3630,8 +3630,8 @@
             !0 !== r.props.accessibleMode &&
               (!r.state.open || r.props.withPortal || r.props.showTimeInput
                 ? r.props.onBlur(e)
-                : r.deferFocusInput(),
-              r.setState({ focused: !1 }));
+                : r.deferFocusInput()),
+              r.setState({ focused: !1 });
           }),
           ue(ve(r), "handleCalendarClickOutside", function(e) {
             r.props.inline || r.setOpen(!1),

--- a/es/index.js
+++ b/es/index.js
@@ -3355,8 +3355,8 @@ var Mt = "Date input not valid.",
           !0 !== a.props.accessibleMode &&
             (!a.state.open || a.props.withPortal || a.props.showTimeInput
               ? a.props.onBlur(e)
-              : a.deferFocusInput(),
-            a.setState({ focused: !1 }));
+              : a.deferFocusInput()),
+            a.setState({ focused: !1 });
         }),
         ce(ve(a), "handleCalendarClickOutside", function(e) {
           a.props.inline || a.setOpen(!1),

--- a/lib/index.js
+++ b/lib/index.js
@@ -3877,8 +3877,8 @@ var INPUT_ERR_1 = "Date input not valid.",
           !0 !== r.props.accessibleMode &&
             (!r.state.open || r.props.withPortal || r.props.showTimeInput
               ? r.props.onBlur(e)
-              : r.deferFocusInput(),
-            r.setState({ focused: !1 }));
+              : r.deferFocusInput()),
+            r.setState({ focused: !1 });
         }),
         _defineProperty(
           _assertThisInitialized(r),

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -382,20 +382,18 @@ export default class DatePicker extends React.Component {
     this.cancelFocusInput();
   };
 
-  handleBlur = event => {
-    if (this.props.accessibleMode === true) {
-      // allow normal de-focusing in a11y mode
-      return;
-    }
-
-    if (
-      this.state.open &&
-      !this.props.withPortal &&
-      !this.props.showTimeInput
-    ) {
-      this.deferFocusInput();
-    } else {
-      this.props.onBlur(event);
+  handleBlur = (event) => {
+    // allows normal de-focusing in a11y mode
+    if (this.props.accessibleMode !== true) {
+      if (
+        this.state.open &&
+        !this.props.withPortal &&
+        !this.props.showTimeInput
+      ) {
+        this.deferFocusInput();
+      } else {
+        this.props.onBlur(event);
+      }
     }
     this.setState({ focused: false });
   };


### PR DESCRIPTION
Currently, when a user types a date into the datepicker input and then blurs, the focused state is not reset. This means an external update of the value prop will not result in the actual value being displayed in the input.

Fixing this bug makes it apparent how closely tied together the start and end datepickers of a range really are. As a result there's a fix in the consumer code that should be deployed before this change is merged in (unless we update the pingboard package.json to point directly to this commit).